### PR TITLE
ntcard: fix edge case of no kmer sampled

### DIFF
--- a/ntcard.cpp
+++ b/ntcard.cpp
@@ -224,6 +224,9 @@ compEst(const uint16_t* t_Counter, double& F0Mean, double fMean[])
 	    (opt::rBits * log(2) - log(pMean[0])) * 1.0 * ((size_t)1 << (opt::sBits + opt::rBits)));
 	for (size_t i = 0; i < 65536; i++)
 		fMean[i] = 0;
+	if (pMean[0] == 0) {
+		return;
+	}
 	fMean[1] = -1.0 * pMean[1] / (pMean[0] * (log(pMean[0]) - opt::rBits * log(2)));
 	for (size_t i = 2; i < 65536; i++) {
 		double sum = 0.0;


### PR DESCRIPTION
When no kmers fit the sampling requirement, ntCard output 2^63 instead of 0. This PR adds a check to outputs 0 when a value is NaN.