### PR TITLE
compatibility with 32 bit platforms

### DIFF
--- a/ntcard.cpp
+++ b/ntcard.cpp
@@ -256,7 +256,7 @@ compEst(const uint16_t* t_Counter, double& F0Mean, double fMean[])
 	}
 
 	F0Mean = (ssize_t)(
-	    (opt::rBits * log(2) - log(pMean[0])) * 1.0 * ((size_t)1 << (opt::sBits + opt::rBits)));
+	    (opt::rBits * log(2) - log(pMean[0])) * 1.0 * ((unsigned long long)1 << (opt::sBits + opt::rBits)));
 	for (size_t i = 0; i < 65536; i++)
 		fMean[i] = 0;
 	if (pMean[0] * (log(pMean[0]) - opt::rBits * log(2)) == 0) {
@@ -289,9 +289,9 @@ outDefault(const std::vector<unsigned>& kList, const size_t totalKmers[], const 
 		double fMean[65536];
 		compEst(t_Counter + k * opt::nSamp * opt::rBuck, F0Mean, fMean);
 		histFiles[k] << "F1\t" << totalKmers[k] << "\n";
-		histFiles[k] << "F0\t" << (size_t)F0Mean << "\n";
+		histFiles[k] << "F0\t" << (unsigned long long)F0Mean << "\n";
 		for (size_t i = 1; i <= opt::covMax; i++)
-			histFiles[k] << i << "\t" << (size_t)fMean[i] << "\n";
+			histFiles[k] << i << "\t" << (unsigned long long)fMean[i] << "\n";
 	}
 	for (unsigned k = 0; k < opt::nK; k++)
 		histFiles[k].close();
@@ -307,9 +307,9 @@ outCompact(const std::vector<unsigned>& kList, const size_t totalKmers[], const 
 		double fMean[65536];
 		compEst(t_Counter + k * opt::nSamp * opt::rBuck, F0Mean, fMean);
 		std::cerr << "k=" << kList[k] << "\tF1\t" << totalKmers[k] << "\n";
-		std::cerr << "k=" << kList[k] << "\tF0\t" << (size_t)F0Mean << "\n";
+		std::cerr << "k=" << kList[k] << "\tF0\t" << (unsigned long long)F0Mean << "\n";
 		for (size_t i = 1; i <= opt::covMax; i++)
-			histFile << kList[k] << "\t" << i << "\t" << (size_t)fMean[i] << "\n";
+			histFile << kList[k] << "\t" << i << "\t" << (unsigned long long)fMean[i] << "\n";
 	}
 	histFile.close();
 }

--- a/ntcard.cpp
+++ b/ntcard.cpp
@@ -256,7 +256,7 @@ compEst(const uint16_t* t_Counter, double& F0Mean, double fMean[])
 	}
 
 	F0Mean = (ssize_t)(
-	    (opt::rBits * log(2) - log(pMean[0])) * 1.0 * ((unsigned long long)1 << (opt::sBits + opt::rBits)));
+	    (opt::rBits * log(2) - log(pMean[0])) * 1.0 * ((uint64_t)1 << (opt::sBits + opt::rBits)));
 	for (size_t i = 0; i < 65536; i++)
 		fMean[i] = 0;
 	if (pMean[0] * (log(pMean[0]) - opt::rBits * log(2)) == 0) {
@@ -289,9 +289,9 @@ outDefault(const std::vector<unsigned>& kList, const size_t totalKmers[], const 
 		double fMean[65536];
 		compEst(t_Counter + k * opt::nSamp * opt::rBuck, F0Mean, fMean);
 		histFiles[k] << "F1\t" << totalKmers[k] << "\n";
-		histFiles[k] << "F0\t" << (unsigned long long)F0Mean << "\n";
+		histFiles[k] << "F0\t" << (uint64_t)F0Mean << "\n";
 		for (size_t i = 1; i <= opt::covMax; i++)
-			histFiles[k] << i << "\t" << (unsigned long long)fMean[i] << "\n";
+			histFiles[k] << i << "\t" << (uint64_t)fMean[i] << "\n";
 	}
 	for (unsigned k = 0; k < opt::nK; k++)
 		histFiles[k].close();
@@ -307,9 +307,9 @@ outCompact(const std::vector<unsigned>& kList, const size_t totalKmers[], const 
 		double fMean[65536];
 		compEst(t_Counter + k * opt::nSamp * opt::rBuck, F0Mean, fMean);
 		std::cerr << "k=" << kList[k] << "\tF1\t" << totalKmers[k] << "\n";
-		std::cerr << "k=" << kList[k] << "\tF0\t" << (unsigned long long)F0Mean << "\n";
+		std::cerr << "k=" << kList[k] << "\tF0\t" << (uint64_t)F0Mean << "\n";
 		for (size_t i = 1; i <= opt::covMax; i++)
-			histFile << kList[k] << "\t" << i << "\t" << (unsigned long long)fMean[i] << "\n";
+			histFile << kList[k] << "\t" << i << "\t" << (uint64_t)fMean[i] << "\n";
 	}
 	histFile.close();
 }
@@ -424,7 +424,7 @@ main(int argc, char** argv)
 			inFiles.push_back(file);
 	}
 
-	unsigned long long int totalSize = 0;
+	uint64_t totalSize = 0;
 	for (unsigned file_i = 0; file_i < inFiles.size(); ++file_i)
 		totalSize += getInf(inFiles[file_i].c_str());
 	if (totalSize < 50000000000)

--- a/ntcard.cpp
+++ b/ntcard.cpp
@@ -424,7 +424,7 @@ main(int argc, char** argv)
 			inFiles.push_back(file);
 	}
 
-	size_t totalSize = 0;
+	unsigned long long int totalSize = 0;
 	for (unsigned file_i = 0; file_i < inFiles.size(); ++file_i)
 		totalSize += getInf(inFiles[file_i].c_str());
 	if (totalSize < 50000000000)


### PR DESCRIPTION
Greetings,

I don't know if there is an interest in 32 bit platforms, but just in case, you may find this of interest.  While attempting to build ntCard on 32 bit intel CPU, the compilation process reported the following issue:

```
ntcard.cpp: In function ‘int main(int, char**)’:
ntcard.cpp:430:16: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  430 |  if (totalSize < 50000000000)
      |      ~~~~~~~~~~^~~~~~~~~~~~~
```
You can also refer to [Debian bug #989855](https://bugs.debian.org/989855).  _totalSize_ is compared against a value of 50 billion.  On 32 bits cpu architectures, a _size_t_ is effectively 32 bits wide, per definition of _size_t_.  However the integer would have overflown already at 5 billion.  On 64 bits cpu architecture, the _size_t_ is 64 bits wide, and given C spefications matches effectively the type of an _unsigned long long_, so aligning to that type should avoid the overflow.

I attempted running your test suite both on virtual machine (_qemu-user_) and real hardware (asus eeepc) after that, and some of the tests had discrepancies, so I ended up bringing a couple more type casts, to make sure 32 bit platforms were returning correct results.  Since _size_t_ matches _unsigned long long_, I believe 64 bit platform have no behavioral changes.

In hope this helps,
Have a nice day,  :)
Étienne.