### PR TITLE
Makefile.am: fix missing files on "clean" target.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,12 +89,12 @@ clang-format:
 	if ls *.fixed; then exit 1; fi
 
 clean-local:
-	rm test-reads.fq.gz
-	rm test_k12.hist
-	rm test-gap_k12.hist
-	rm test-rna-reads.fq.gz
-	rm test-rna_k12.hist
-	rm test-rna-gap_k12.hist
-	rm test-reads.fa
-	rm test-fa_k12.hist
-	rm test-fa-gap_k12.hist
+	$(RM) test-reads.fq.gz
+	$(RM) test_k12.hist
+	$(RM) test-gap_k12.hist
+	$(RM) test-rna-reads.fq.gz
+	$(RM) test-rna_k12.hist
+	$(RM) test-rna-gap_k12.hist
+	$(RM) test-reads.fa
+	$(RM) test-fa_k12.hist
+	$(RM) test-fa-gap_k12.hist


### PR DESCRIPTION
As seen on [Debian bug #1049666], running the "clean" target under certain circumstances may cause the rule to fail with:

	rm: cannot remove 'test-reads.fq.gz': No such file or directory

This is because the rm commands are not forcefully run, with flag -f. One way to address this is to use the built-in $(RM) from default make variables, which typically will result in running rm -f instead of plain rm, in turn resulting in no failure if the file hasn't been generated in the first place.

If this variable were to not to be trusted for whatever reason, there is also the option to set it explicitly first, e.g. `RM = rm -vf`.

[Debian bug #1049666]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1049666